### PR TITLE
Add Local LLM (Ollama) Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,21 @@ To create a new API key:
 I would suggest setting up a payment method in the Google AI Studio so you can get the limits of the Tier 1 payment tier. Once set up, using tostr should cost only a couple cents per project if anything, since it uses the `Gemini Flash-Lite` model for all its description generation. You can very easily set a spend limit in Google's UI if you like by going to the `Spend` tab after creating your key.
 
 #### Installing Environment Variables on Mac:
-To expose your API key to tostr in a specific terminal session, run this command:
+To expose your API key or local model configurations to tostr in a specific terminal session, run these commands:
+
+For Gemini (Default):
 ```bash
 export GEMINI_API_KEY=[your api key]
 ```
-> This will only save the key in the current session. To save the key permanently and system-wide, follow the instructions [here](https://www.youtube.com/watch?v=nfcAcfpeQ0Q)
+
+For Local LLM (Ollama):
+```bash
+export TOSTR_LLM_PROVIDER="ollama"
+export TOSTR_LLM_MODEL="llama3" # Optional, defaults to llama3
+export TOSTR_LLM_BASE_URL="http://localhost:11434" # Optional
+```
+
+> This will only save the keys in the current session. To save the key permanently and system-wide, follow the instructions [here](https://www.youtube.com/watch?v=nfcAcfpeQ0Q)
 
 #### Installing Environment Variables on Windows:
 In order to save environment variables on Windows, follow these steps.
@@ -99,7 +109,7 @@ In order to save environment variables on Windows, follow these steps.
     * **User variables**: Only accessible by your specific Windows account.
     * **System variables**: Accessible by all users on the computer (requires Administrator privileges).
 4. Click `New...` under the chosen section
-5. Enter `GEMINI_API_KEY` in the name, and paste your API key from the Google AI Studio
+5. For Gemini, enter `GEMINI_API_KEY` in the name, and paste your API key from the Google AI Studio. For Local LLM, enter `TOSTR_LLM_PROVIDER` and set the value to `ollama`. You can optionally also set `TOSTR_LLM_MODEL`.
 6. Click OK on all open windows to save the settings.
 > Note: You must restart any open command prompts for them to recognize the new variable.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "pathspec",
     "sqlite-vec",
     "onnxruntime",
-    "tokenizers"
+    "tokenizers",
+    "ollama"
 ]
 
 [project.scripts]

--- a/src/tostr/commands.py
+++ b/src/tostr/commands.py
@@ -31,11 +31,36 @@ def _verify_db_exists(target_path: Path):
         )
 
 def get_llm_client(progress_tracker: "ProgressTracker" = None):
-    GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
-    if GEMINI_API_KEY is None:
-        raise APIKeyError("API key not found.")
+    provider = os.getenv("TOSTR_LLM_PROVIDER", "gemini").lower()
     
-    strategy = GeminiStrategy(api_key=GEMINI_API_KEY)
+    if provider == "ollama":
+        from tostr.semantic.llm import OllamaStrategy
+        model_name = os.getenv("TOSTR_LLM_MODEL")
+        base_url = os.getenv("TOSTR_LLM_BASE_URL", "http://localhost:11434")
+        
+        if not model_name:
+            try:
+                import ollama
+                client = ollama.Client(host=base_url)
+                models = client.list()
+                if models and 'models' in models and len(models['models']) > 0:
+                    model_name = models['models'][0]['name']
+                    logger.info(f"Auto-detected available Ollama model: {model_name}")
+                else:
+                    model_name = "llama3"
+            except Exception as e:
+                logger.warning(f"Could not auto-detect Ollama models, defaulting to llama3: {e}")
+                model_name = "llama3"
+                
+        logger.info(f"Using local Ollama model: {model_name} at {base_url}")
+        strategy = OllamaStrategy(model_name=model_name, base_url=base_url)
+
+    else:
+        GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+        if GEMINI_API_KEY is None:
+            raise APIKeyError("API key not found. Set GEMINI_API_KEY or use TOSTR_LLM_PROVIDER=ollama")
+        strategy = GeminiStrategy(api_key=GEMINI_API_KEY)
+        
     return LLMClient(strategy=strategy, progress_tracker=progress_tracker)
 
 @lru_cache(maxsize=1)

--- a/src/tostr/semantic/llm/__init__.py
+++ b/src/tostr/semantic/llm/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
 from .base import LLMClient, LLMResponse, LLMStrategy
 from .gemini import GeminiStrategy
+from .ollama import OllamaStrategy
 from .prompts import CLASS_SYSTEM_INSTRUCTION, FILE_SYSTEM_INSTRUCTION, DIRECTORY_SYSTEM_INSTRUCTION

--- a/src/tostr/semantic/llm/ollama.py
+++ b/src/tostr/semantic/llm/ollama.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from pydantic import BaseModel
+from tostr.semantic.llm.base import LLMStrategy
+from typing import Type
+
+class OllamaStrategy(LLMStrategy):
+    def __init__(self, api_key: str = "", model_name: str = "llama3", base_url: str = "http://localhost:11434", max_concurrent_requests: int = 10):
+        import ollama
+        super().__init__(api_key, model_name, max_concurrent_requests)
+        self.client = ollama.AsyncClient(host=base_url)
+        self.model_name = model_name
+
+    async def generate(self, input_data_string: str, system_instruction: str, response_schema: Type[BaseModel]):
+        try:
+            # Note: LLMClient handles retries and semaphore
+            response = await self.client.chat(
+                model=self.model_name,
+                messages=[
+                    {'role': 'system', 'content': system_instruction},
+                    {'role': 'user', 'content': input_data_string}
+                ],
+                format=response_schema.model_json_schema(),
+                options={
+                    "temperature": 0.2,
+                    "num_ctx": 8192
+                }
+            )
+
+            return response_schema.model_validate_json(response['message']['content'])
+        except Exception as e:
+            # Re-raise to let LLMClient handle retries
+            raise e


### PR DESCRIPTION
Added an Ollama strategy and environment variable configuration to support generating descriptions via local models offline, auto-detecting installed models if none are explicitly provided.